### PR TITLE
Add dumi docs configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # OSSManager Combined Project
+
+This repository contains the frontend and backend of the OSSManager system.
+
+## Documentation
+
+The frontend documentation is generated with [dumi](https://d.umijs.org/).
+
+```bash
+cd frontend
+npm run docs:dev    # start local docs server
+npm run docs:build  # build static docs
+```

--- a/frontend/.dumirc.ts
+++ b/frontend/.dumirc.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'dumi';
+
+export default defineConfig({
+  themeConfig: {
+    name: 'OSSManager',
+  },
+  outputPath: 'dist-docs',
+});

--- a/frontend/docs/index.md
+++ b/frontend/docs/index.md
@@ -1,0 +1,9 @@
+# OSSManager 文档
+
+欢迎阅读 OSSManager 前端文档。本项目的文档由 [dumi](https://d.umijs.org) 生成。
+
+## 文档列表
+
+- [环境配置说明](./环境配置说明.md)
+- [HTTP/2 SSE 连接问题解决方案](./http2-sse-issue.md)
+- [上传进度与速度显示实现文档](./stream-upload.md)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,9 @@
     "start": "next start",
     "start:test": "next start --env-file=.env.test",
     "start:prod": "next start --env-file=.env.production",
-    "lint": "next lint"
+    "lint": "next lint",
+    "docs:dev": "dumi dev",
+    "docs:build": "dumi build"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.2.4",
@@ -57,6 +59,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.2.3",
     "postcss": "^8.5.3",
-    "typescript": "^5"
+    "typescript": "^5",
+    "dumi": "^2.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- set up dumi in the frontend project
- add documentation index and config file
- document how to run docs in the project README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867340d0d70832a933c507fb18b1cfb