### PR TITLE
docs: fix framer motion reference

### DIFF
--- a/docs/overview.html
+++ b/docs/overview.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>OSS Manager Overview</title>
+    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/framer-motion@11.0.3/dist/framer-motion.umd.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel" data-presets="env,react">
+      const { motion } = window.framerMotion;
+
+      function App() {
+        return (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.5 }}
+          >
+            <h1>Overview</h1>
+          </motion.div>
+        );
+      }
+
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(<App />);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add overview doc with React example
- use `window.framerMotion` to get motion
- enable JSX compilation via `data-presets="env,react"`

## Testing
- `go test ./internal/api/handlers -run '^$'` *(fails: undefined: db.SetDB)*
- `npx playwright@1.42.1 install chromium` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ecb882fb4832abc9e9f242ce8c6ee